### PR TITLE
Impl Debug for struct types

### DIFF
--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,8 +1,7 @@
 use kmod_sys;
 use errno;
 
-use std::ptr;
-use std::mem;
+use std::{fmt, mem, ptr};
 use std::ffi::CString;
 
 use modules::{Module, ModuleIterator};
@@ -121,4 +120,10 @@ impl Context {
         dirname.to_string_lossy().into_owned()
     }
     */
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("Context { .. }")
+    }
 }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -3,6 +3,7 @@ use reduce::Reduce;
 use errno;
 
 use std::ffi::{CStr, CString};
+use std::fmt;
 use errors::{Result, ErrorKind};
 
 
@@ -107,6 +108,11 @@ impl Module {
     }
 }
 
+impl fmt::Debug for Module {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("Module { .. }")
+    }
+}
 
 /// Iterator over a kmod_list of modules
 pub struct ModuleIterator {
@@ -146,3 +152,10 @@ impl Iterator for ModuleIterator {
         }
     }
 }
+
+impl fmt::Debug for ModuleIterator {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("ModuleIterator { .. }")
+    }
+}
+


### PR DESCRIPTION
Impl fmt::Debug for kmod struct types. Uses an opaque impl so that no internal details are revealed, but makes it easy to derive Debug on structs which contain these types