### PR TITLE
Make insert_module() accept parameters as slice of &str to avoid allocation when possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ travis-ci = { repository = "kpcyrd/kmod-rs" }
 error-chain = "0.12"
 log = "0.4"
 errno = "0.2"
-reduce = "0.1"
 kmod-sys = { version = "0.1.2", path = "kmod-sys" }
 
 [dev-dependencies]

--- a/examples/insmod.rs
+++ b/examples/insmod.rs
@@ -17,5 +17,5 @@ fn main() {
 
     let module = ctx.module_new_from_path(&filename).expect("new_from_path failed");
     info!("got module: {:?}", module.name());
-    module.insert_module(0, args).expect("insert_module failed");
+    module.insert_module(0, &args.iter().map(|x| x.as_str()).collect::<Vec<_>>()).expect("insert_module failed");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,6 @@
 #[macro_use] extern crate error_chain;
 #[macro_use] extern crate log;
 extern crate errno;
-extern crate reduce;
 extern crate kmod_sys;
 
 mod errors {

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -1,11 +1,9 @@
 use kmod_sys::{self, kmod_list, kmod_module};
-use reduce::Reduce;
 use errno;
 
 use std::ffi::{CStr, CString};
 use std::fmt;
 use errors::{Result, ErrorKind};
-
 
 /// Wrapper around a kmod_module
 pub struct Module {
@@ -81,10 +79,8 @@ impl Module {
 
     /// Insert the module into the kernel
     #[inline]
-    pub fn insert_module(&self, flags: u32, opts: Vec<String>) -> Result<()> {
-        let opts = opts.into_iter()
-            .reduce(|a, b| a + " " + &b)
-            .unwrap_or(String::new());
+    pub fn insert_module(&self, flags: u32, opts: &[&str]) -> Result<()> {
+        let opts = opts.join(" ");
 
         let opts = CString::new(opts)?;
 


### PR DESCRIPTION
Also drop the reduce dependency in favor of slice::join(" ") call