### PR TITLE
Make name() return &str instead of the owned String

### DIFF
--- a/examples/lsmod.rs
+++ b/examples/lsmod.rs
@@ -12,7 +12,7 @@ fn main() {
         let size = module.size();
 
         let holders: Vec<_> = module.holders()
-                                .map(|x| x.name())
+                                .map(|x| x.name().to_owned())
                                 .collect();
 
         println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!         let size = module.size();
 //!
 //!         let holders: Vec<_> = module.holders()
-//!             .map(|x| x.name())
+//!             .map(|x| x.name().to_owned())
 //!             .collect();
 //!
 //!         println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);
@@ -66,7 +66,7 @@ mod tests {
             let size = module.size();
 
             let holders: Vec<_> = module.holders()
-                                    .map(|x| x.name())
+                                    .map(|x| x.name().to_owned())
                                     .collect();
 
             println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -30,10 +30,9 @@ impl Module {
 
     /// Get the name of the module
     #[inline]
-    pub fn name(&self) -> String {
-        let name = unsafe { kmod_sys::kmod_module_get_name(self.inner) };
-        let name = unsafe { CStr::from_ptr(name) };
-        name.to_string_lossy().into_owned()
+    pub fn name(&self) -> &str {
+        let name = unsafe { kmod_sys::kmod_module_get_name(self.inner).as_ref() };
+        name.and_then(|ptr| unsafe { CStr::from_ptr(ptr) }.to_str().ok()).unwrap()
     }
 
     /// Get the size of the module


### PR DESCRIPTION
Don't account for NULL as libkmod states that name is always available