### PR TITLE
Better use &OsStr than &str

### DIFF
--- a/examples/lsmod.rs
+++ b/examples/lsmod.rs
@@ -7,13 +7,14 @@ fn main() {
     let ctx = kmod::Context::new().expect("kmod ctx failed");
 
     for module in ctx.modules_loaded().unwrap() {
-        let name = module.name();
+        let name = module.name().to_string_lossy();
         let refcount = module.refcount();
         let size = module.size();
 
-        let holders: Vec<_> = module.holders()
-                                .map(|x| x.name().to_owned())
-                                .collect();
+        let holders: Vec<_> = module
+            .holders()
+            .map(|x| x.name().to_string_lossy().into_owned())
+            .collect();
 
         println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,23 @@
 //!
 //! # Example
 //! ```
-//! fn main() {
+//! fn main() -> Result<(), Box<std::error::Error>>{
 //!     // create a new kmod context
-//!     let ctx = kmod::Context::new().unwrap();
+//!     let ctx = kmod::Context::new()?;
 //!
 //!     // get a kmod_list of all loaded modules
-//!     for module in ctx.modules_loaded().unwrap() {
-//!         let name = module.name();
+//!     for module in ctx.modules_loaded()? {
+//!         let name = module.name().to_string_lossy();
 //!         let refcount = module.refcount();
 //!         let size = module.size();
 //!
 //!         let holders: Vec<_> = module.holders()
-//!             .map(|x| x.name().to_owned())
+//!             .map(|x| x.name().to_string_lossy().into_owned())
 //!             .collect();
 //!
 //!         println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);
 //!     }
+//!     Ok(())
 //! }
 //! ```
 
@@ -58,15 +59,26 @@ mod tests {
         let ctx = Context::new().unwrap();
 
         for module in ctx.modules_loaded().unwrap() {
-            let name = module.name();
+            let name = module.name().to_string_lossy();
             let refcount = module.refcount();
             let size = module.size();
 
-            let holders: Vec<_> = module.holders()
-                                    .map(|x| x.name().to_owned())
-                                    .collect();
+            let holders: Vec<_> = module
+                .holders()
+                .map(|x| x.name().to_string_lossy().into_owned())
+                .collect();
 
             println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);
         }
+    }
+
+    #[test]
+    fn bad_name() {
+        let ctx = Context::new().unwrap();
+        let m = ctx
+            .module_new_from_name("/lib/modules/5.1.12-300.fc30.x86_64/kernel/fs/cifs/cifs.ko.xz")
+            .unwrap();
+        println!("name: {:?}", m.name());
+        println!("path: {:?}", m.path());
     }
 }


### PR DESCRIPTION
We can't be sure about UTF-8 correctness. Absolutely not.
For example, if we don't print the path, we can just use it for PathBuf
directly and be sure nothing was lost in the conversion.
And if we want to print the path, we can use whatever conversion fits.