### PR TITLE
Module::name: return an Option

### DIFF
--- a/examples/lsmod.rs
+++ b/examples/lsmod.rs
@@ -7,13 +7,13 @@ fn main() {
     let ctx = kmod::Context::new().expect("kmod ctx failed");
 
     for module in ctx.modules_loaded().unwrap() {
-        let name = module.name().to_string_lossy();
+        let name = module.name().unwrap_or_default().to_string_lossy();
         let refcount = module.refcount();
         let size = module.size();
 
         let holders: Vec<_> = module
             .holders()
-            .map(|x| x.name().to_string_lossy().into_owned())
+            .map(|x| x.name().unwrap_or_default().to_string_lossy().into_owned())
             .collect();
 
         println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,12 @@
 //!
 //!     // get a kmod_list of all loaded modules
 //!     for module in ctx.modules_loaded()? {
-//!         let name = module.name().to_string_lossy();
+//!         let name = module.name().unwrap_or_default().to_string_lossy();
 //!         let refcount = module.refcount();
 //!         let size = module.size();
 //!
 //!         let holders: Vec<_> = module.holders()
-//!             .map(|x| x.name().to_string_lossy().into_owned())
+//!             .map(|x| x.name().unwrap_or_default().to_string_lossy().into_owned())
 //!             .collect();
 //!
 //!         println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);
@@ -59,13 +59,13 @@ mod tests {
         let ctx = Context::new().unwrap();
 
         for module in ctx.modules_loaded().unwrap() {
-            let name = module.name().to_string_lossy();
+            let name = module.name().unwrap_or_default().to_string_lossy();
             let refcount = module.refcount();
             let size = module.size();
 
             let holders: Vec<_> = module
                 .holders()
-                .map(|x| x.name().to_string_lossy().into_owned())
+                .map(|x| x.name().unwrap_or_default().to_string_lossy().into_owned())
                 .collect();
 
             println!("{:<19} {:8}  {} {:?}", name, size, refcount, holders);
@@ -80,5 +80,16 @@ mod tests {
             .unwrap();
         println!("name: {:?}", m.name());
         println!("path: {:?}", m.path());
+    }
+
+    #[test]
+    fn module_name_none() {
+        use std::ffi::OsString;
+        let ctx = Context::new().unwrap();
+         for m in ctx
+            .module_new_from_lookup(OsString::from("dgfhdfjkghdl").as_ref())
+            .unwrap() {
+             assert!(m.name().is_none());
+         }
     }
 }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -31,7 +31,7 @@ impl Module {
 
     /// Get the name of the module
     #[inline]
-    pub fn name(&self) -> &OsStr {
+    pub fn name(&self) -> Option<&OsStr> {
         unsafe {
             kmod_sys::kmod_module_get_name(self.inner)
                 .as_ref()
@@ -39,7 +39,6 @@ impl Module {
         }
         .map(CStr::to_bytes)
         .map(OsStr::from_bytes)
-        .unwrap() // Don't account for NULL as libkmod states that name is always available
     }
 
     /// Get the size of the module


### PR DESCRIPTION
Getting the name can return NULL/None.

```rust
for m in kmod_ctx.module_new_from_lookup(OsString::from("kdfgkj").as_ref())? {
    let name = m.name(); // <- Can return None
}
```